### PR TITLE
Upgrade to LXCFS 5.0.0

### DIFF
--- a/deployment/lxcfs-daemonset.yaml
+++ b/deployment/lxcfs-daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: lxcfs

--- a/lxcfs-image/Dockerfile
+++ b/lxcfs-image/Dockerfile
@@ -1,19 +1,24 @@
-FROM centos:7 as build
-RUN yum -y update
-RUN yum -y install fuse-devel pam-devel wget install gcc automake autoconf libtool make
-ENV LXCFS_VERSION 3.1.2
+FROM ubuntu:20.04 as build
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update -y
+RUN apt-get install -y fuse libfuse-dev wget build-essential meson python3 python3-jinja2 cmake pkg-config
+
+ENV LXCFS_VERSION 5.0.0
 RUN wget https://linuxcontainers.org/downloads/lxcfs/lxcfs-$LXCFS_VERSION.tar.gz && \
 	mkdir /lxcfs && tar xzvf lxcfs-$LXCFS_VERSION.tar.gz -C /lxcfs  --strip-components=1 && \
-	cd /lxcfs && ./configure && make
+	cd /lxcfs && meson setup -Dinit-script=systemd --prefix=/lxcfs build/ && \
+    meson install -C build/
 
-FROM centos:7
+FROM ubuntu:20.04
 STOPSIGNAL SIGINT
-COPY --from=build /lxcfs/lxcfs /usr/local/bin/lxcfs
-COPY --from=build /lxcfs/.libs/liblxcfs.so /usr/local/lib/lxcfs/liblxcfs.so
-COPY --from=build /lxcfs/lxcfs /lxcfs/lxcfs
-COPY --from=build /lxcfs/.libs/liblxcfs.so /lxcfs/liblxcfs.so
-COPY --from=build /usr/lib64/libfuse.so.2.9.2 /lxcfs/libfuse.so.2.9.2
-COPY --from=build /usr/lib64/libulockmgr.so.1.0.1 /lxcfs/libulockmgr.so.1.0.1
+COPY --from=build /lxcfs/bin/lxcfs /usr/local/bin/lxcfs
+COPY --from=build /lxcfs/lib/x86_64-linux-gnu/lxcfs/liblxcfs.so /usr/lib/x86_64-linux-gnu/liblxcfs.so
+COPY --from=build /usr/lib/x86_64-linux-gnu/libfuse.so.2.9.9 /usr/lib/x86_64-linux-gnu/libfuse.so.2.9.9
+COPY --from=build /usr/lib/x86_64-linux-gnu/libulockmgr.so.1.0.1 /usr/lib/x86_64-linux-gnu/libulockmgr.so.1.0.1
+
+RUN ldconfig
+
+RUN mkdir -p /usr/local/lib/lxcfs /var/lib/lxcfs
 
 COPY start.sh /
 CMD ["/start.sh"]

--- a/lxcfs-image/start.sh
+++ b/lxcfs-image/start.sh
@@ -11,15 +11,5 @@ rm -rf /var/lib/lxcfs/*
 # Prepare
 mkdir -p /usr/local/lib/lxcfs /var/lib/lxcfs
 
-# Update lxcfs
-cp -f /lxcfs/lxcfs /usr/local/bin/lxcfs
-cp -f /lxcfs/liblxcfs.so /usr/local/lib/lxcfs/liblxcfs.so
-
-cp -f /lxcfs/libfuse.so.2.9.2 /usr/lib64/libfuse.so.2.9.2
-cp -f /lxcfs/libulockmgr.so.1.0.1 /usr/lib64/libulockmgr.so.1.0.1
-
-ln -s /usr/lib64/libfuse.so.2.9.2 /usr/lib64/libfuse.so.2
-ln -s /usr/lib64/libulockmgr.so.1.0.1 /usr/lib64/libulockmgr.so.1
-
 # Mount
 exec nsenter -m/proc/1/ns/mnt /usr/local/bin/lxcfs /var/lib/lxcfs/

--- a/lxcfs.go
+++ b/lxcfs.go
@@ -75,12 +75,15 @@ var volumeMountsTemplate = []corev1.VolumeMount{
 		ReadOnly:  true,
 	},
 }
+
+var volumeHostPathType = corev1.HostPathFile
 var volumesTemplate = []corev1.Volume{
 	{
 		Name: "lxcfs-proc-cpuinfo",
 		VolumeSource: corev1.VolumeSource{
 			HostPath: &corev1.HostPathVolumeSource{
 				Path: "/var/lib/lxcfs/proc/cpuinfo",
+				Type: &volumeHostPathType,
 			},
 		},
 	},
@@ -89,6 +92,7 @@ var volumesTemplate = []corev1.Volume{
 		VolumeSource: corev1.VolumeSource{
 			HostPath: &corev1.HostPathVolumeSource{
 				Path: "/var/lib/lxcfs/proc/diskstats",
+				Type: &volumeHostPathType,
 			},
 		},
 	},
@@ -97,6 +101,7 @@ var volumesTemplate = []corev1.Volume{
 		VolumeSource: corev1.VolumeSource{
 			HostPath: &corev1.HostPathVolumeSource{
 				Path: "/var/lib/lxcfs/proc/meminfo",
+				Type: &volumeHostPathType,
 			},
 		},
 	},
@@ -105,6 +110,7 @@ var volumesTemplate = []corev1.Volume{
 		VolumeSource: corev1.VolumeSource{
 			HostPath: &corev1.HostPathVolumeSource{
 				Path: "/var/lib/lxcfs/proc/stat",
+				Type: &volumeHostPathType,
 			},
 		},
 	},
@@ -113,6 +119,7 @@ var volumesTemplate = []corev1.Volume{
 		VolumeSource: corev1.VolumeSource{
 			HostPath: &corev1.HostPathVolumeSource{
 				Path: "/var/lib/lxcfs/proc/swaps",
+				Type: &volumeHostPathType,
 			},
 		},
 	},
@@ -121,6 +128,7 @@ var volumesTemplate = []corev1.Volume{
 		VolumeSource: corev1.VolumeSource{
 			HostPath: &corev1.HostPathVolumeSource{
 				Path: "/var/lib/lxcfs/proc/uptime",
+				Type: &volumeHostPathType,
 			},
 		},
 	},
@@ -129,6 +137,7 @@ var volumesTemplate = []corev1.Volume{
 		VolumeSource: corev1.VolumeSource{
 			HostPath: &corev1.HostPathVolumeSource{
 				Path: "/var/lib/lxcfs/proc/loadavg",
+				Type: &volumeHostPathType,
 			},
 		},
 	},
@@ -137,6 +146,7 @@ var volumesTemplate = []corev1.Volume{
 		VolumeSource: corev1.VolumeSource{
 			HostPath: &corev1.HostPathVolumeSource{
 				Path: "/var/lib/lxcfs/sys/devices/system/cpu/online",
+				Type: &volumeHostPathType,
 			},
 		},
 	},


### PR DESCRIPTION
Rebased on upstream.

 Uses Ubuntu base image and does not copy binary and lib to host. Not sure it will work, but worth a shot. Needs testing in cesarnetes.